### PR TITLE
fix block_total_lenght error in light_alloc_block()

### DIFF
--- a/src/light_alloc.c
+++ b/src/light_alloc.c
@@ -54,8 +54,8 @@ light_pcapng light_alloc_block(uint32_t block_type, const uint32_t *block_body, 
 
 	PADD32(block_body_length, &actual_size);
 
-	pcapng_block->block_total_lenght = actual_size; // This value MUST be a multiple of 4.
-	block_body_size = actual_size - 2 * sizeof(pcapng_block->block_total_lenght) - sizeof(pcapng_block->block_type);
+	pcapng_block->block_total_lenght = actual_size + 2 * sizeof(pcapng_block->block_total_lenght) - sizeof(pcapng_block->block_type); // This value MUST be a multiple of 4.
+	block_body_size = actual_size;
 
 	if (block_body_size > 0) {
 		pcapng_block->block_body = calloc(1, block_body_size);

--- a/src/light_alloc.c
+++ b/src/light_alloc.c
@@ -54,7 +54,7 @@ light_pcapng light_alloc_block(uint32_t block_type, const uint32_t *block_body, 
 
 	PADD32(block_body_length, &actual_size);
 
-	pcapng_block->block_total_lenght = actual_size + 2 * sizeof(pcapng_block->block_total_lenght) - sizeof(pcapng_block->block_type); // This value MUST be a multiple of 4.
+	pcapng_block->block_total_lenght = actual_size + 2 * sizeof(pcapng_block->block_total_lenght) + sizeof(pcapng_block->block_type); // This value MUST be a multiple of 4.
 	block_body_size = actual_size;
 
 	if (block_body_size > 0) {


### PR DESCRIPTION
the pcapng_block->block_total_lenght and actual_size got messed up